### PR TITLE
Added GCES to the list

### DIFF
--- a/lib/domains/np/edu/gces.txt
+++ b/lib/domains/np/edu/gces.txt
@@ -1,0 +1,1 @@
+Gandaki College of Engineering and Science


### PR DESCRIPTION
GCES stands for Gandaki College of Engineering and Science. This is a college from Pokhara, Nepal.